### PR TITLE
Fix broken Instagram and LinkedIn logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 
 ### Connect with me:
 
-[<img align="left" alt="codeSTACKr | LinkedIn" width="22px" src="https://www.flaticon.com/svg/vstatic/svg/174/174857.svg?token=exp=1618658874~hmac=00a7f91a826a2c8fc749b7624dfd2616" />][linkedin]
-[<img align="left" alt="codeSTACKr | Instagram" width="22px" src="https://www.flaticon.com/svg/vstatic/svg/174/174855.svg?token=exp=1618663100~hmac=5be3f1459db3863638690f97d217fc6c" />][instagram]
+[<img align="left" alt="codeSTACKr | LinkedIn" width="22px" src="https://image.flaticon.com/icons/png/512/174/174857.png" />][linkedin]
+[<img align="left" alt="codeSTACKr | Instagram" width="22px" src="https://upload.wikimedia.org/wikipedia/commons/e/e7/Instagram_logo_2016.svg" />][instagram]
 
 <br />
 


### PR DESCRIPTION
Both logos were having an invalid link. I've fixed it.